### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ nav.share iframe {border:0; margin-top:0; padding-top:0;} /* if using medium siz
 If you use the default configuration options and styling above, the output should appear as:
 <img src="https://cloud.githubusercontent.com/assets/28847/3418917/8883ea2e-fe51-11e3-81f4-368f184b9a49.png" alt="horizontal row of evenly aligned social media buttons." />
 
-###Turbolinks
+### Turbolinks
 **Important:** If your project uses Rails 4 then it's very likely you should set the *turbolinks* option to **true**. Otherwise social buttons won't appear on pages loaded via Turbolinks (Turbolinks is default in Rails 4 unless explicitly disabled).
 
 This gem works with Turbolinks however the javascript library [jQuery](https://github.com/rails/jquery-rails) is required. Turbolinks support in Shareable is turned off by default. To enable Turbolinks support, first make sure your app includes jQuery then set configuration option *turbolinks* in your local 'shareable.rb' [configuration](https://github.com/hermango/shareable/blob/master/README.md#configuration) file to boolean **true**. The *turbolinks* option can also be passed as a hash value to the render_shareable method like this:


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
